### PR TITLE
unistd.h not available on windows, and appears to be uncessary

### DIFF
--- a/node_curve.cc
+++ b/node_curve.cc
@@ -3,7 +3,6 @@
 #include <node_buffer.h>
 #include <string.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include "curve25519-donna.c"
 
 #include <nan.h>


### PR DESCRIPTION
This header is not available on windows, and it seems simply removing it causes no problems.
